### PR TITLE
feat: s3にCORS設定をする

### DIFF
--- a/terraform/env/production/main.tf
+++ b/terraform/env/production/main.tf
@@ -58,8 +58,9 @@ module "golio" {
   }
 
   domain = {
-    domain_name = local.golio_domain
-    name        = "folio-api"
+    domain_name     = local.golio_domain
+    name            = "folio-api"
+    reolio_base_url = local.reolio_base_url
   }
 
   cidr_block = "10.0.0.0/16"

--- a/terraform/modules/golio/main.tf
+++ b/terraform/modules/golio/main.tf
@@ -108,4 +108,7 @@ module "rds" {
 module "media_s3" {
   source = "./s3"
   name   = local.media_s3_name
+  cors = {
+    allowed_origins = [var.domain.reolio_base_url]
+  }
 }

--- a/terraform/modules/golio/s3/main.tf
+++ b/terraform/modules/golio/s3/main.tf
@@ -2,3 +2,20 @@
 resource "aws_s3_bucket" "this" {
   bucket = var.name
 }
+
+resource "aws_s3_bucket_cors_configuration" "this" {
+  bucket = aws_s3_bucket.this.id
+
+  cors_rule {
+    allowed_headers = ["*"]
+    allowed_methods = ["PUT"]
+    allowed_origins = var.cors.allowed_origins
+    max_age_seconds = 3000
+  }
+
+  cors_rule {
+    allowed_headers = ["*"]
+    allowed_methods = ["GET"]
+    allowed_origins = var.cors.allowed_origins
+  }
+}

--- a/terraform/modules/golio/s3/variables.tf
+++ b/terraform/modules/golio/s3/variables.tf
@@ -1,3 +1,9 @@
 variable "name" {
   type = string
 }
+
+variable "cors" {
+  type = object({
+    allowed_origins : list(string)
+  })
+}

--- a/terraform/modules/golio/variables.tf
+++ b/terraform/modules/golio/variables.tf
@@ -36,6 +36,7 @@ variable "domain" {
   type = object({
     domain_name : string
     name : string
+    reolio_base_url : string
   })
 }
 variable "cidr_block" {


### PR DESCRIPTION
## 概要
タイトルの通り

## terraform
```terraform
  # module.golio.module.media_s3.aws_s3_bucket_cors_configuration.this will be created
  + resource "aws_s3_bucket_cors_configuration" "this" {
      + bucket = "production-golio-media"
      + id     = (known after apply)

      + cors_rule {
          + allowed_headers = [
              + "*",
            ]
          + allowed_methods = [
              + "GET",
            ]
          + allowed_origins = [
              + "https://folio.sunjin.info",
            ]
          + expose_headers  = []
        }
      + cors_rule {
          + allowed_headers = [
              + "*",
            ]
          + allowed_methods = [
              + "PUT",
            ]
          + allowed_origins = [
              + "https://folio.sunjin.info",
            ]
          + expose_headers  = []
          + max_age_seconds = 3000
        }
    }

```