### PR TITLE
fix: [terraform] dependabotでaws操作できる様にする

### DIFF
--- a/terraform/modules/deployment/aws.tf
+++ b/terraform/modules/deployment/aws.tf
@@ -6,6 +6,12 @@ resource "github_actions_secret" "aws_secret_arn" {
   plaintext_value = aws_iam_role.iam.arn
 }
 
+resource "github_dependabot_secret" "aws_secret_arn" {
+  repository      = "folio"
+  secret_name     = "AWS_ROLE_TO_ASSUME"
+  plaintext_value = aws_iam_role.iam.arn
+}
+
 data "http" "github_actions_openid_configuration" {
   url = "https://token.actions.githubusercontent.com/.well-known/openid-configuration"
 }

--- a/terraform/modules/deployment/main.tf
+++ b/terraform/modules/deployment/main.tf
@@ -23,7 +23,7 @@ resource "github_actions_secret" "cloudflare_account_id" {
 resource "cloudflare_api_token" "cloudflare_api_token" {
   name = "github_actions_access_token"
 
-  policies = [{
+  policy {
     permission_groups = [
       data.cloudflare_api_token_permission_groups.all.account["Pages Write"],
       data.cloudflare_api_token_permission_groups.all.account["Pages Read"],
@@ -32,18 +32,18 @@ resource "cloudflare_api_token" "cloudflare_api_token" {
     resources = {
       "com.cloudflare.api.account.${var.cloudflare.account_id}" = "*"
     }
-    },
-    {
-      permission_groups = [
-        data.cloudflare_api_token_permission_groups.all.user["User Details Read"],
-        data.cloudflare_api_token_permission_groups.all.user["Memberships Read"]
-      ]
-      resources = {
-        # ここの文字列が何かわからないので、これを究明する必要がある
-        "com.cloudflare.api.user.c6c05087bac8efd53e5dff1e626574e8" = "*"
-      }
+  }
+
+  policy {
+    permission_groups = [
+      data.cloudflare_api_token_permission_groups.all.user["User Details Read"],
+      data.cloudflare_api_token_permission_groups.all.user["Memberships Read"]
+    ]
+    resources = {
+      # ここの文字列が何かわからないので、これを究明する必要がある
+      "com.cloudflare.api.user.c6c05087bac8efd53e5dff1e626574e8" = "*"
     }
-  ]
+  }
 }
 
 # Account permissions


### PR DESCRIPTION
# 概要
dependabotでAWSのassume roleにアクセスできていなかったため修正
